### PR TITLE
add feedback link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,8 @@
           <h1>{{ site.title | default: site.github.repository_name }}</h1>
           <h3><center>{{ site.description | default: site.github.project_tagline }}</center></h3>
           <hr>
-          
+          <span class="credits left">Project maintained by <a href="{{ site.github_page }}">{{ site.github_username }}</a></span>
+          <span class="credits right">Theme: modified version of <a href="https://github.com/pages-themes/midnight/">midnight</a></span>
         </div>
 
         {{ content }}
@@ -52,12 +53,10 @@
 
     <footer>
             <div>
-               <center>
-                 <span class="credits left">Project maintained by <a href="{{ site.github_page }}">{{ site.github_username }}</a></span>
-                <span class="credits right">Theme: modified version of <a href="https://github.com/pages-themes/midnight/">midnight</a></span>
-               </center>
+                <center>
+                  If you have suggestions or want to change something please give us <a href="https://github.com/nushell/blog">feedback</a>
+                </center>
            </div>
     </footer>
-
   </body>
 </html>

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -194,7 +194,7 @@ table {
       list-style: none;
       display: inline;
       color: white;
-      line-height: 20px;
+      line-height: min-content;
       text-shadow: 0px 1px 0px rgba(0,0,0,.2);
       font-size: 14px;
       margin-top: 10px;


### PR DESCRIPTION
That's what I came up with to avoid a bloated footer:
![blog_desktop](https://user-images.githubusercontent.com/52786998/69496046-0b11f700-0ece-11ea-8eee-85e1b4ba0549.png)

![blog_mobile](https://user-images.githubusercontent.com/52786998/69496045-0b11f700-0ece-11ea-96c8-9ad9f4fe3b97.png)

another option would be to leave the other two things out

What are your thoughts on this?