### PR TITLE
Fix random integer command

### DIFF
--- a/_posts/2020-09-22-nushell_0_20.md
+++ b/_posts/2020-09-22-nushell_0_20.md
@@ -71,7 +71,7 @@ Completions can [now be case-insensitive](https://github.com/nushell/nushell/pul
 
 ## Command Improvements
 
-* **NEW** [`random int`](https://github.com/nushell/nushell/pull/2489) - create random integers (smaydew)
+* **NEW** [`random integer`](https://github.com/nushell/nushell/pull/2489) - create random integers (smaydew)
 * **NEW** [`exec`](https://github.com/nushell/nushell/pull/2495) - on Unix-based systems with exec support, you can now call the built-in `exec` command (almindor)
 * **NEW** [`mod`](https://github.com/nushell/nushell/pull/2505) - a new modulo operator (jonathandturner)
 
@@ -97,7 +97,7 @@ Completions can [now be case-insensitive](https://github.com/nushell/nushell/pul
 
 ## Other improvements (fdncred, gillespiecd, lidin, andrasio, radekvit, jonathandturner, coolshaurya)
 
-Removed unnused dependencies, cleanups to duration, some ARM incompatibilites were fixed, some Ctrl+C issues were fixed, optimized some config reading, cleanup code in `get` and `nu-value-ext`, rustyline was upgraded (fixing a common instability in Windows), `help command` get some improvements, `random int` got some stability fixes.
+Removed unnused dependencies, cleanups to duration, some ARM incompatibilites were fixed, some Ctrl+C issues were fixed, optimized some config reading, cleanup code in `get` and `nu-value-ext`, rustyline was upgraded (fixing a common instability in Windows), `help command` get some improvements, `random integer` got some stability fixes.
 
 # Breaking changes
 


### PR DESCRIPTION
Changed `random int` to be `random integer`, which is the actual command.